### PR TITLE
Revert "Bump boto3 from 1.13.11 to 1.14.8"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.14.8
+boto3==1.13.11
 python-lambda==11.7.1
 requests==2.24.0


### PR DESCRIPTION
Reverts GovWizely/lambda-ita-office-locations#49

ERROR: python-lambda 11.7.1 has requirement boto3==1.4.4, but you'll have boto3 1.14.7 which is incompatible.
